### PR TITLE
Add Proto DataStore, Update Dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlin_version"
     id 'com.google.devtools.ksp' version "$ksp_version"
     id 'com.google.gms.google-services'
+    id 'com.google.protobuf' version '0.9.1'
 }
 
 android {
@@ -29,17 +30,17 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.0'
+        kotlinCompilerExtensionVersion '1.4.4'
     }
     packagingOptions {
         resources {
@@ -73,6 +74,10 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.5.3'
     implementation 'androidx.compose.material:material-icons-extended:1.4.0'
 
+    // Proto DataStore
+    implementation 'androidx.datastore:datastore:1.0.0'
+    implementation 'com.google.protobuf:protobuf-javalite:3.22.2'
+
     // Room
     def room_version = '2.5.1'
     implementation "androidx.room:room-runtime:$room_version"
@@ -97,4 +102,20 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+}
+
+// Protobuf lite code generation
+protobuf {
+    protoc {
+        artifact = 'com.google.protobuf:protoc:3.22.2'
+    }
+    generateProtoTasks {
+        all().configureEach { task ->
+            task.builtins {
+                java {
+                    option "lite"
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/copixelate/data/proto/UserSettingsSerializer.kt
+++ b/app/src/main/java/com/copixelate/data/proto/UserSettingsSerializer.kt
@@ -1,0 +1,33 @@
+package com.copixelate.data.proto
+
+import android.content.Context
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import com.copixelate.UserSettings
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+object UserSettingsSerializer : Serializer<UserSettings> {
+    override val defaultValue: UserSettings = UserSettings.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): UserSettings {
+        try {
+            return UserSettings.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    override suspend fun writeTo(
+        t: UserSettings,
+        output: OutputStream
+    ) = t.writeTo(output)
+}
+
+val Context.settingsDataStore: DataStore<UserSettings> by dataStore(
+    fileName = "user_settings.pb",
+    serializer = UserSettingsSerializer
+)

--- a/app/src/main/proto/user_settings.proto
+++ b/app/src/main/proto/user_settings.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package copixelate;
+
+option java_multiple_files = true;
+option java_package = "com.copixelate";
+
+message UserSettings {
+  ThemeType theme_type = 1;
+}
+
+enum ThemeType {
+  DEFAULT = 0;
+  DARK = 1;
+  LIGHT = 2;
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlin_version = '1.8.0'
-        ksp_version = kotlin_version + '-1.0.8'
+        kotlin_version = '1.8.10'
+        ksp_version = kotlin_version + '-1.0.9'
     }
     dependencies {
         classpath 'com.google.gms:google-services:4.3.15'
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
+    id 'com.android.application' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'org.jetbrains.kotlin.jvm' version "$kotlin_version" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Aug 03 17:32:47 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This pull request adds the foundation for using Proto DataStore to save User Settings, including initial ProtoBuff setup and several dependency updates.