### PR TITLE
Remove opt-in annotations no longer required

### DIFF
--- a/app/src/main/java/com/copixelate/ui/MainContent.kt
+++ b/app/src/main/java/com/copixelate/ui/MainContent.kt
@@ -23,7 +23,6 @@ import com.copixelate.viewmodel.LibraryViewModel
 import com.copixelate.viewmodel.NavViewModel
 import com.copixelate.viewmodel.SettingsViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainContent(
     navController: NavHostController,

--- a/app/src/main/java/com/copixelate/ui/components/TextInputFields.kt
+++ b/app/src/main/java/com/copixelate/ui/components/TextInputFields.kt
@@ -117,7 +117,6 @@ fun SecretTextInputField(
 }// End SecretTextInputField
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 fun ImeActionTextInputField(
     value: String,
     onValueChange: (value: String) -> Unit,

--- a/app/src/main/java/com/copixelate/ui/screens/AuthScreen.kt
+++ b/app/src/main/java/com/copixelate/ui/screens/AuthScreen.kt
@@ -103,7 +103,6 @@ private enum class FormAction {
 }
 
 @Composable
-@OptIn(ExperimentalMaterial3Api::class)
 private fun AuthForm(
     onSignUp: (email: String, displayName: String, password: String) -> Unit,
     onSignIn: (email: String, password: String) -> Unit


### PR DESCRIPTION
This pull request removes Opt-In Annotations for the Experimental Material 3 API that are no longer required.