### PR TITLE
Simplify .gitignore IDE rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,22 +17,8 @@ captures/
 output.json
 
 # IntelliJ
+.idea/
 *.iml
-.idea/caches/
-.idea/libraries/
-.idea/shelf/
-.idea/.name
-.idea/misc.xml
-.idea/modules.xml
-.idea/compiler.xml
-.idea/kotlinc.xml
-.idea/gradle.xml
-.idea/vcs.xml
-.idea/workspace.xml
-.idea/navEditor.xml
-.idea/assetWizardSettings.xml
-.idea/deploymentTargetDropDown.xml
-.idea/render.experimental.xml
 
 # Keystore files
 *.jks


### PR DESCRIPTION
This pull request simplifies the .gitignore IDE rules by ignoring the entire directory instead of individual files and sub-directories. 