### PR TITLE
Add unique file naming for exported images

### DIFF
--- a/app/src/main/java/com/copixelate/data/storage/StorageAdapter.kt
+++ b/app/src/main/java/com/copixelate/data/storage/StorageAdapter.kt
@@ -36,7 +36,7 @@ object StorageAdapter {
         }
 
         val newImageDetails = ContentValues().apply {
-            put(MediaStore.Images.Media.DISPLAY_NAME, fileName)
+            put(MediaStore.Images.Media.DISPLAY_NAME, "$fileName.png")
             put(MediaStore.Images.Media.IS_PENDING, 1)
         }
 

--- a/app/src/main/java/com/copixelate/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/com/copixelate/ui/screens/library/LibraryScreen.kt
@@ -35,9 +35,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.copixelate.R
 import com.copixelate.data.model.SpaceModel
 import com.copixelate.data.model.toArtSpace
 import com.copixelate.ui.animation.AnimationCatalog.libraryItemEnter
@@ -243,13 +245,22 @@ private fun LibraryScreenContent(
             onCancel = { showCreateDialog = false }
         )
 
+    val context = LocalContext.current
+    val exportFileNamePrefix = remember {
+        context.getString(R.string.export_filename_prefix) +
+                context.getString(R.string.export_filename_separator)
+    }
+
+    fun generateUniqueFilename() =
+        exportFileNamePrefix + System.currentTimeMillis().toString()
+
     // Dialog, export image
     if (showExportDialog)
         ExportImageDialog(
             onExport = { scaleFactor ->
                 onExport(
                     spaceModelToExport,
-                    "copixelate-tmp.png",
+                    generateUniqueFilename(),
                     scaleFactor
                 )
             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,8 @@
     <string name="nav_content_description_contacts_add">Go to Add Contacts</string>
     <string name="nav_content_description_settings">Go to Settings</string>
 
+    <!-- Export File Naming -->
+    <string name="export_filename_prefix">@string/app_name</string>
+    <string name="export_filename_separator">-</string>
+
 </resources>


### PR DESCRIPTION
This pull request adds generation of unique file names for images exported to file.

`fun generateUniqueFilename() =
        exportFileNamePrefix + System.currentTimeMillis().toString()`