### PR TITLE
Add signing configuration for release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ output.json
 # Keystore files
 *.jks
 *.keystore
+keystore.properties
 
 # Google Services (e.g. APIs or Firebase)
 # google-services.json

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -23,8 +26,22 @@ android {
         ksp { arg("room.schemaLocation", "$projectDir/schemas") }
     }
 
+    signingConfigs {
+        create("release") {
+            // Retrieve signing credentials from secret file
+            Properties().run {
+                load(FileInputStream(project.file("keystore.properties")))
+                storePassword = this["storePassword"] as String
+                keyPassword = this["keyPassword"] as String
+                keyAlias = this["keyAlias"] as String
+                storeFile = file(this["storeFile"] as String)
+            }
+        }
+    }
+
     buildTypes {
         getByName("release") {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(

--- a/app/keystore.properties
+++ b/app/keystore.properties
@@ -1,0 +1,4 @@
+storePassword=store_password
+keyPassword=key_password
+keyAlias=key_alias
+storeFile=/path/to/keystore.jks


### PR DESCRIPTION
This pull request adds a signing configuration for release builds, which uses a new secret file (keystore.properties) to store credentials.